### PR TITLE
Fix gaming js classes and add highlight style

### DIFF
--- a/assets/css/gaming.css
+++ b/assets/css/gaming.css
@@ -290,6 +290,11 @@
   flex-wrap: wrap;
 }
 
+.highlight {
+  font-weight: bold;
+  color: var(--accent-color, #ff3366);
+}
+
 .review-content {
   display: flex;
   flex-direction: column;

--- a/assets/js/generate/gaming/generate-gaming.js
+++ b/assets/js/generate/gaming/generate-gaming.js
@@ -6,7 +6,7 @@ fetch("assets/data/butikker.json")
 
     gamingStores.forEach(store => {
       const card = document.createElement("div");
-      card.className = "store-card gaming-store-card";
+      card.className = "gaming-store-card";
       card.innerHTML = `
         <a href="${store.url}" target="_blank" rel="noopener">
           <img src="${store.image}" alt="${store.alt}" />

--- a/assets/js/generate/gaming/generate-spillkalender.js
+++ b/assets/js/generate/gaming/generate-spillkalender.js
@@ -11,8 +11,8 @@ document.addEventListener("DOMContentLoaded", () => {
       filterBox.className = "filter-box";
       filterBox.innerHTML = `
         <div>
-          <label for="plattformVelger" class="form-label mb-0 me-2">Plattform:</label>
-          <select id="plattformVelger" class="form-select d-inline-block w-auto">
+          <label for="plattformVelger" class="form-label">Plattform:</label>
+          <select id="plattformVelger" class="form-select">
             <option value="alle">Alle</option>
             <option value="PC">PC</option>
             <option value="PS5">PS5</option>
@@ -21,8 +21,8 @@ document.addEventListener("DOMContentLoaded", () => {
           </select>
         </div>
         <div>
-          <label for="maanedVelger" class="form-label mb-0 me-2">Måned:</label>
-          <select id="maanedVelger" class="form-select d-inline-block w-auto">
+          <label for="maanedVelger" class="form-label">Måned:</label>
+          <select id="maanedVelger" class="form-select">
             <option value="alle">Alle</option>
             ${[...Array(12)].map((_, i) => {
               const m = String(i + 1).padStart(2, "0");
@@ -32,7 +32,7 @@ document.addEventListener("DOMContentLoaded", () => {
           </select>
         </div>
         <div>
-          <button id="nullstillFilter" class="btn btn-sm btn-secondary">Nullstill filter</button>
+          <button id="nullstillFilter">Nullstill filter</button>
         </div>
       `;
       container.appendChild(filterBox);
@@ -78,7 +78,7 @@ document.addEventListener("DOMContentLoaded", () => {
           spillSomVises = dataToRender.slice(0, maksAntall);
 
           const visAlleKnapp = document.createElement("button");
-          visAlleKnapp.className = "btn btn-outline-light mt-3 vis-alle-knapp";
+          visAlleKnapp.className = "vis-alle-knapp";
           visAlleKnapp.textContent = `Vis alle (${dataToRender.length}) spill`;
           visAlleKnapp.addEventListener("click", () => render(dataToRender, false));
           container.appendChild(visAlleKnapp);

--- a/assets/js/generate/gaming/generate-tips.js
+++ b/assets/js/generate/gaming/generate-tips.js
@@ -6,7 +6,7 @@ fetch("assets/data/tips.json")
     const buttons = document.querySelectorAll("#tips-filters button");
 
     const visMerKnapp = document.createElement("button");
-    visMerKnapp.className = "btn btn-outline-light mt-3";
+    visMerKnapp.className = "btn";
     visMerKnapp.textContent = "Vis alle";
     visMerKnapp.style.display = "none";
 


### PR DESCRIPTION
## Summary
- drop unused `store-card` class from generated gaming cards
- remove Bootstrap-like classes from gaming JS
- add `.highlight` style in gaming CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68623c69391483258fbf7e61e9992782